### PR TITLE
add idle-conn-timeout option for Redis clusters

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -53,12 +53,15 @@ func newCacheRedis(layerName string, addr string, db int, TTL time.Duration, red
 	}
 }
 
-func newCacheClusterRedis(layerName string, masterAddr string, slaveAddrs []string, db int, TTL time.Duration, amnesiaChance int, compressionEnabled bool, watcher *epimetheus.TimerWithCounter) *cache {
+func newCacheClusterRedis(layerName string, masterAddr string, slaveAddrs []string, db int, TTL time.Duration, redisIdleTimeout time.Duration, amnesiaChance int, compressionEnabled bool, watcher *epimetheus.TimerWithCounter) *cache {
 	slaveClients := make([]*redis.Client, len(slaveAddrs))
 	for i, addr := range slaveAddrs {
 		redisOptions := &redis.Options{
 			Addr: addr,
 			DB:   db,
+		}
+		if redisIdleTimeout >= time.Second {
+			redisOptions.IdleTimeout = redisIdleTimeout
 		}
 		slaveClients[i] = redis.NewClient(redisOptions)
 	}

--- a/core.go
+++ b/core.go
@@ -91,6 +91,7 @@ func newMnemosyneInstance(name string, config *viper.Viper, watcher *epimetheus.
 				config.GetStringSlice(keyPrefix+".slaves"),
 				config.GetInt(keyPrefix+".db"),
 				config.GetDuration(keyPrefix+".ttl"),
+				config.GetDuration(keyPrefix+".idle-timeout"),
 				config.GetInt(keyPrefix+".amnesia"),
 				config.GetBool(keyPrefix+".compression"),
 				commTimer,


### PR DESCRIPTION
Redis Cluster initiation was missing the `idle-timeout` option for its Redis connection.