### PR TITLE
Invalidated data

### DIFF
--- a/c-redis.go
+++ b/c-redis.go
@@ -100,7 +100,7 @@ func (rc *redisCache) Set(ctx context.Context, key string, value interface{}) er
 	}
 	client := rc.pickClient(key, true).WithContext(ctx)
 	startMarker := rc.watcher.Start()
-	setError := client.SetNX(key, finalData, rc.cacheTTL).Err()
+	setError := client.Set(key, finalData, rc.cacheTTL).Err()
 	if setError != nil {
 		rc.watcher.Done(startMarker, rc.layerName, "set", "error")
 	} else {


### PR DESCRIPTION
To set data in Redis, command SET was being used with NX option which only applies the data when no previous data is stored in the database under the same Key. As mnemosyne caching mechanisms is hardly relied on SoftTTL mechanism, using SET NX avoids the library to update the cache as it's planned and data with passed SoftTTL duration will still remain in the database until it reaches to its actual TTL and no processes can update it before.