### PR TITLE
Uses set instead of setnx to avoid invalidated data to keep

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -215,7 +215,7 @@ func (cr *cache) set(key string, value interface{}) (setError error) {
 	}
 	client := cr.baseRedisClient.WithContext(cr.ctx)
 	startMarker := cr.watcher.Start()
-	setError = client.SetNX(key, finalData, cr.cacheTTL).Err()
+	setError = client.Set(key, finalData, cr.cacheTTL).Err()
 	if setError != nil {
 		cr.watcher.Done(startMarker, cr.layerName, "set", "error")
 	} else {


### PR DESCRIPTION
To set data in Redis, command SET was being used with NX option which only applies the data when no previous data is stored in the database under the same Key. As mnemosyne caching mechanisms is hardly relied on SoftTTL mechanism, using SET NX avoids the library to update the cache as it's planned and data with passed SoftTTL duration will still remain in the database until it reaches to its actual TTL and no processes can update it before.